### PR TITLE
Feat: add session tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ npm run change-password <username> <password>
 
 ### Like collection
 
-- user (user._id)
-- movie (movie._id)
+- userId (user._id)
+- movieId (movie._id)
 - status (boolean, true = liked, false = disliked)
+
+## Session data schema
+
+The user session, available on `request.session` inside a route handler, has the
+following properties:
+
+```ts
+interface Session {
+    userId: string; // The ID of the currently authenticated user
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "connect-mongo": "^5.1.0",
         "express": "^4.21.2",
         "express-session": "^1.18.1",
         "mongodb": "^6.13.1"
@@ -74,6 +75,18 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -93,6 +106,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -219,6 +238,46 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/connect-mongo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-5.1.0.tgz",
+      "integrity": "sha512-xT0vxQLqyqoUTxPLzlP9a/u+vir0zNkhiy9uAdHjSCcUUf7TS5b55Icw8lVyYFxfemP3Mf9gdwUOgeF3cxCAhw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "kruptein": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "peerDependencies": {
+        "express-session": "^1.17.1",
+        "mongodb": ">= 5.1.0 < 7"
+      }
+    },
+    "node_modules/connect-mongo/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/connect-mongo/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -704,6 +763,18 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/kruptein": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-3.0.7.tgz",
+      "integrity": "sha512-vTftnEjfbqFHLqxDUMQCj6gBo5lKqjV4f0JsM8rk8rM3xmvFZ2eSy4YALdaye7E+cDKnEj7eAjFR3vwh8a4PgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1.js": "^5.4.1"
+      },
+      "engines": {
+        "node": ">8"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -778,6 +849,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
+        "express-session": "^1.18.1",
         "mongodb": "^6.13.1"
       },
       "devDependencies": {
@@ -403,6 +404,40 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -916,6 +951,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -986,6 +1030,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -1295,6 +1348,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undefsafe": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
+    "express-session": "^1.18.1",
     "mongodb": "^6.13.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "change-password": "node src/scripts/changePassword.js"
   },
   "dependencies": {
+    "connect-mongo": "^5.1.0",
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "mongodb": "^6.13.1"

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,24 @@
 
 import express from "express";
 import * as path from "node:path";
-import {loginPost} from "./pages/login.js";
+import { loginPost } from "./pages/login.js";
+import session from "express-session";
 
 const app = express();
+app.use(session({
+    resave: true,
+    saveUninitialized: true,
+    // TODO: we need a better secret i guess.
+    secret: "weh"
+}));
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static(path.join(import.meta.dirname, "static")));
 
 app.post("/login.html", loginPost);
+
+app.get("/whoami", (request, response) => {
+    response.send(request.session).end();
+});
 
 const listener = app.listen(3000, () => {
     const { port } = listener.address();

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import session from "express-session";
 
 const app = express();
 app.use(session({
-    maxAge: 24 * 60 * 60 * 1000,// 24 hours
+    maxAge: 24 * 60 * 60 * 1000, // 24 hours
     resave: true,
     saveUninitialized: true,
     // TODO: we need a better secret i guess.

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,13 @@
  * authentication.
  */
 
+import MongoStore from "connect-mongo";
 import express from "express";
-import * as path from "node:path";
-import { loginPost } from "./pages/login.js";
 import session from "express-session";
+import * as path from "node:path";
+import { client as mongoClient } from "./mongodb.js";
+import { renderGallery } from "./pages/gallery.js";
+import { loginPost } from "./pages/login.js";
 
 const app = express();
 app.use(session({
@@ -14,16 +17,18 @@ app.use(session({
     resave: true,
     saveUninitialized: true,
     // TODO: we need a better secret i guess.
-    secret: "weh"
+    secret: "weh",
+    store: new MongoStore({ client: mongoClient, dbName: "video-platform" })
 }));
 app.use(express.urlencoded({ extended: true }));
-app.use(express.static(path.join(import.meta.dirname, "static")));
 
 app.post("/login.html", loginPost);
 
 app.get("/whoami", (request, response) => {
     response.send(request.session).end();
 });
+
+app.use(express.static(path.join(import.meta.dirname, "static")));
 
 const listener = app.listen(3000, () => {
     const { port } = listener.address();

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import session from "express-session";
 
 const app = express();
 app.use(session({
+    maxAge: 24 * 60 * 60 * 1000,// 24 hours
     resave: true,
     saveUninitialized: true,
     // TODO: we need a better secret i guess.

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -2,7 +2,7 @@ import hashPassword from "../hashPassword.js";
 import { userCollection } from "../mongodb.js";
 import validatePassword from "../validatePassword.js";
 
-export async function loginPost (request, response) {
+export async function loginPost(request, response) {
     const { username, password } = request.body;
 
     if (!validatePassword(password)) {
@@ -34,11 +34,16 @@ export async function loginPost (request, response) {
         }
         return;
     }
-    // On successfull login, redirect to the gallery
+
+    // Reset the login attempts to zero
     await userCollection.updateOne(
         { username },
         { $set: { failedLoginAttempts: 0 } }
     );
-    response.redirect(302, "/gallery.html"); // Temporary redirect
 
+    // Update the user session to show that the user is logged in
+    request.session.user = user._id;
+
+    // On successfull login, redirect to the gallery
+    response.redirect(302, "/gallery.html"); // Temporary redirect
 }

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -42,7 +42,7 @@ export async function loginPost(request, response) {
     );
 
     // Update the user session to show that the user is logged in
-    request.session.user = user._id;
+    request.session.userId = user._id;
 
     // On successfull login, redirect to the gallery
     response.redirect(302, "/gallery.html"); // Temporary redirect


### PR DESCRIPTION
This pull request adds user session tracking to allow the server to track whether a user is currently logged in or not. The session is available on `request.session`, and basic schema documentation has been added to the readme. An example/utility route has been added, `/whoami` that will return the current user's session, which may be useful for debugging.